### PR TITLE
sys: sync with upstream manifest

### DIFF
--- a/base/gatekeeper.yaml
+++ b/base/gatekeeper.yaml
@@ -330,7 +330,7 @@ spec:
                   fieldPath: metadata.name
             - name: SECRET_NAME
               value: gatekeeper-webhook-server-secret
-          image: quay.io/open-policy-agent/gatekeeper:dev
+          image: quay.io/open-policy-agent/gatekeeper:v3.0.4-beta.1
           imagePullPolicy: Always
           name: manager
           ports:
@@ -348,7 +348,7 @@ spec:
             - mountPath: /certs
               name: cert
               readOnly: true
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: cert
           secret:


### PR DESCRIPTION
this includes a container image release (v3.0.4-beta.1) which supports namespaces other than gatekeeper-system (which was the bug that was forcing us to use the 'dev' tag)