### PR TITLE
sys: adjust resource limits to avoid latency for api server requests

### DIFF
--- a/base/gatekeeper.yaml
+++ b/base/gatekeeper.yaml
@@ -339,10 +339,12 @@ spec:
               protocol: TCP
           resources:
             limits:
-              cpu: 100m
-              memory: 512Mi
+              # increased from the relatively low defaults provided by the upstream manifest; 100m cpu caused very slow request
+              # latencies to the api server
+              cpu: 7000m
+              memory: 1000Mi
             requests:
-              cpu: 100m
+              cpu: 200m
               memory: 256Mi
           volumeMounts:
             - mountPath: /certs


### PR DESCRIPTION
A cpu limit of `100m` was too low to deal with the volume of requests generated by intercepting all `CREATE` and `UPDATE` events, so I've increased the request to `200m` as a baseline and the limit to `7000m`.

I've also increased the memory limit to `1000m` to give it a little more headroom, given its importance.