### PR TITLE
v3.1.0-beta.0

### DIFF
--- a/cluster/gatekeeper-cluster-role.yaml
+++ b/cluster/gatekeeper-cluster-role.yaml
@@ -5,145 +5,125 @@ metadata:
   name: gatekeeper-manager-role
 rules:
   - apiGroups:
-      - "*"
-    resources:
-      - "*"
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-      - patch
-  - apiGroups:
-      - config.gatekeeper.sh
-    resources:
-      - configs
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - config.gatekeeper.sh
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - update
-      - patch
-  - apiGroups:
-      - constraints.gatekeeper.sh
-    resources:
-      - "*"
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - templates.gatekeeper.sh
-    resources:
-      - constrainttemplates
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - templates.gatekeeper.sh
-    resources:
-      - constrainttemplates/status
-    verbs:
-      - get
-      - update
-      - patch
-  - apiGroups:
-      - constraints.gatekeeper.sh
-    resources:
-      - "*"
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - "*"
-    resources:
-      - "*"
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - ""
     resources:
       - configmaps
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
-      - update
       - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
       - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - "*"
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - admissionregistration.k8s.io
     resources:
       - mutatingwebhookconfigurations
       - validatingwebhookconfigurations
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
-      - update
       - patch
-      - delete
+      - update
+      - watch
   - apiGroups:
-      - ""
+      - apiextensions.k8s.io
     resources:
-      - secrets
+      - customresourcedefinitions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - config.gatekeeper.sh
+    resources:
+      - configs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - config.gatekeeper.sh
+    resources:
+      - configs/status
     verbs:
       - get
-      - list
-      - watch
-      - create
-      - update
       - patch
-      - delete
+      - update
   - apiGroups:
-      - ""
+      - constraints.gatekeeper.sh
     resources:
-      - services
+      - "*"
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
-      - update
       - patch
+      - update
+      - watch
+  - apiGroups:
+      - templates.gatekeeper.sh
+    resources:
+      - constrainttemplates
+    verbs:
+      - create
       - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - templates.gatekeeper.sh
+    resources:
+      - constrainttemplates/status
+    verbs:
+      - get
+      - patch
+      - update

--- a/cluster/gatekeeper-crds.yaml
+++ b/cluster/gatekeeper-crds.yaml
@@ -1,18 +1,21 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.2
   creationTimestamp: null
-  labels:
-    controller-tools.k8s.io: "1.0"
   name: configs.config.gatekeeper.sh
 spec:
   group: config.gatekeeper.sh
   names:
     kind: Config
+    listKind: ConfigList
     plural: configs
+    singular: config
   scope: Namespaced
   validation:
     openAPIV3Schema:
+      description: Config is the Schema for the configs API
       properties:
         apiVersion:
           description:
@@ -29,6 +32,7 @@ spec:
         metadata:
           type: object
         spec:
+          description: ConfigSpec defines the desired state of Config
           properties:
             sync:
               description: Configuration for syncing k8s objects
@@ -80,6 +84,7 @@ spec:
               type: object
           type: object
         status:
+          description: ConfigStatus defines the observed state of Config
           properties:
             byPod:
               description: List of statuses as seen by individual pods
@@ -103,7 +108,12 @@ spec:
                 type: object
               type: array
           type: object
+      type: object
   version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
 status:
   acceptedNames:
     kind: ""
@@ -159,6 +169,10 @@ spec:
             targets:
               items:
                 properties:
+                  libs:
+                    items:
+                      type: string
+                    type: array
                   rego:
                     type: string
                   target:

--- a/cluster/gatekeeper-webhook.yaml
+++ b/cluster/gatekeeper-webhook.yaml
@@ -1,0 +1,18 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: gatekeeper-validating-webhook-configuration
+webhooks:
+  - name: validation.gatekeeper.sh
+    clientConfig:
+      caBundle: Cg==
+      service:
+        name: gatekeeper-webhook-service
+        path: /v1/admit
+    failurePolicy: Ignore
+    namespaceSelector:
+      matchExpressions:
+        - key: control-plane
+          operator: DoesNotExist
+    sideEffects: None
+    timeoutSeconds: 5

--- a/cluster/kustomization.yaml
+++ b/cluster/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - gatekeeper-cluster-role.yaml
   - gatekeeper-crds.yaml
+  - gatekeeper-webhook.yaml

--- a/example/gatekeeper-patch.yaml
+++ b/example/gatekeeper-patch.yaml
@@ -1,0 +1,36 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: gatekeeper-validating-webhook-configuration
+  annotations:
+    # Placeholder, patch with the gatekeeper namespace value
+    certmanager.k8s.io/inject-ca-from: example-namespace/gatekeeper-serving-cert
+webhooks:
+  - name: validation.gatekeeper.sh
+    clientConfig:
+      service:
+        # Placeholder, patch with the gatekeeper namespace value
+        namespace: example-namespace
+    rules:
+      - apiGroups:
+          - "*"
+        apiVersions:
+          - "*"
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - "namespaces"
+          - "ingresses"
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: gatekeeper-serving-cert
+spec:
+  # Placeholder, patch with the gatekeeper namespace value
+  commonName: gatekeeper-webhook-service.example-namespace.svc
+  dnsNames:
+    # Placeholder, patch with the gatekeeper namespace value
+    - gatekeeper-webhook-service.example-namespace.svc.cluster.local

--- a/example/gatekeeper.yaml
+++ b/example/gatekeeper.yaml
@@ -6,9 +6,7 @@ metadata:
 spec:
   sync:
     syncOnly:
-      - group: ""
-        version: "v1"
+      - version: "v1"
         kind: "Namespace"
-      - group: "extensions"
-        version: "v1beta1"
+      - version: "v1beta1"
         kind: "Ingress"

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -5,6 +5,8 @@ bases:
   #  - github.com/utilitywarehouse/gatekeeper-manifests/cluster?ref=3.0.4-beta.2-1
   - ../namespaced
   #  - github.com/utilitywarehouse/gatekeeper-manifests/namespaced?ref=3.0.4-beta.2-1
+patchesStrategicMerge:
+  - gatekeeper-patch.yaml
 resources:
-  - gatekeeper-cluster-role-binding.yaml
-  - gatekeeper-config.yaml
+  - gatekeeper.yaml
+  - rbac.yaml

--- a/example/rbac.yaml
+++ b/example/rbac.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  creationTimestamp: null
   name: gatekeeper-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11,4 +10,4 @@ subjects:
   - kind: ServiceAccount
     name: default
     # Placeholder, patch with the gatekeeper namespace value
-    namespace: example
+    namespace: example-namespace

--- a/namespaced/gatekeeper.yaml
+++ b/namespaced/gatekeeper.yaml
@@ -1,46 +1,54 @@
-apiVersion: v1
-kind: Secret
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Issuer
 metadata:
-  name: gatekeeper-webhook-server-secret
+  name: gatekeeper-selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: gatekeeper-serving-cert
+spec:
+  issuerRef:
+    kind: Issuer
+    name: gatekeeper-selfsigned-issuer
+  secretName: gatekeeper-webhook-server-cert
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
-  name: gatekeeper-controller-manager-service
+  name: gatekeeper-webhook-service
 spec:
   ports:
     - port: 443
       targetPort: 8443
   selector:
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
   name: gatekeeper-controller-manager
 spec:
+  replicas: 1
   selector:
     matchLabels:
       control-plane: controller-manager
-      controller-tools.k8s.io: "1.0"
-  serviceName: gatekeeper-controller-manager-service
   template:
     metadata:
       labels:
         control-plane: controller-manager
-        controller-tools.k8s.io: "1.0"
     spec:
       containers:
         - args:
-            - --auditInterval=30
-            - --port=8443
+            - -auditInterval=30
+            - -port=8443
+            - -disable-cert-rotation
+          command:
+            - /manager
           env:
             - name: POD_NAMESPACE
               valueFrom:
@@ -51,9 +59,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: SECRET_NAME
-              value: gatekeeper-webhook-server-secret
-          image: quay.io/open-policy-agent/gatekeeper:v3.0.4-beta.2
+          image: quay.io/open-policy-agent/gatekeeper:v3.1.0-beta.0
           imagePullPolicy: Always
           name: manager
           ports:
@@ -78,4 +84,4 @@ spec:
         - name: cert
           secret:
             defaultMode: 420
-            secretName: gatekeeper-webhook-server-secret
+            secretName: gatekeeper-webhook-server-cert


### PR DESCRIPTION
The latest release of gatekeeper upgrades to kubebuilder v2, which allows you to manage the webhook resource yourself and provision the webhook certificate with cert-manager (provided you use the cainjector to inject the CA).

This PR syncs with the manifests provided by the upstream here: https://github.com/open-policy-agent/gatekeeper/blob/master/deploy/gatekeeper.yaml

As illustrated by `example/gatekeeper-patch.yaml`, the patch should define the `ValidatingWebhookConfiguration` rules that govern which events and resources are forwarded to the webhook.