### PR TITLE
remove caBundle from the webhook

### DIFF
--- a/cluster/gatekeeper-webhook.yaml
+++ b/cluster/gatekeeper-webhook.yaml
@@ -5,7 +5,6 @@ metadata:
 webhooks:
   - name: validation.gatekeeper.sh
     clientConfig:
-      caBundle: Cg==
       service:
         name: gatekeeper-webhook-service
         path: /v1/admit


### PR DESCRIPTION
Otherwise `kubectl apply` replaces the certificate provisioned by cert-manager with the empty string.