### PR TITLE
3.1.0-beta.2

### DIFF
--- a/namespaced/gatekeeper.yaml
+++ b/namespaced/gatekeeper.yaml
@@ -60,7 +60,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          image: quay.io/open-policy-agent/gatekeeper:v3.1.0-beta.1
+          image: quay.io/open-policy-agent/gatekeeper:v3.1.0-beta.2
           imagePullPolicy: Always
           name: manager
           ports:


### PR DESCRIPTION
There was a deadlock in the previous release.

https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.1.0-beta.2