### PR TITLE
move cert-manager objects out of the base

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Refer to the `example/`.
 Note that you need to [provide the `ClusterRoleBinding` for gatekeeper's service
 account](example/rbac.yaml). This is required in order to keep the base namespace-agnostic.
 
+The `namespaced` base sets the `--disable-cert-rotation` flag, which means you must manage the webhook certificate, in a secret called `gatekeeper-webhook-server-cert`, separately. Additionally, the CA certificate must be injected into the `ValidatingWebhookConfiguration`. The example uses cert-manager and cert-manager's cainjector to achieve both things.
+
 ## Requires
 
 - https://github.com/kubernetes-sigs/kustomize

--- a/example/gatekeeper-patch.yaml
+++ b/example/gatekeeper-patch.yaml
@@ -23,14 +23,3 @@ webhooks:
         resources:
           - "namespaces"
           - "ingresses"
----
-apiVersion: certmanager.k8s.io/v1alpha1
-kind: Certificate
-metadata:
-  name: gatekeeper-serving-cert
-spec:
-  # Placeholder, patch with the gatekeeper namespace value
-  commonName: gatekeeper-webhook-service.example-namespace.svc
-  dnsNames:
-    # Placeholder, patch with the gatekeeper namespace value
-    - gatekeeper-webhook-service.example-namespace.svc.cluster.local

--- a/example/gatekeeper.yaml
+++ b/example/gatekeeper.yaml
@@ -10,3 +10,25 @@ spec:
         kind: "Namespace"
       - version: "v1beta1"
         kind: "Ingress"
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Issuer
+metadata:
+  name: gatekeeper-selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: gatekeeper-serving-cert
+spec:
+  # Placeholder, patch with the gatekeeper namespace value
+  commonName: gatekeeper-webhook-service.example-namespace.svc
+  dnsNames:
+    # Placeholder, patch with the gatekeeper namespace value
+    - gatekeeper-webhook-service.example-namespace.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: gatekeeper-selfsigned-issuer
+  secretName: gatekeeper-webhook-server-cert

--- a/namespaced/gatekeeper.yaml
+++ b/namespaced/gatekeeper.yaml
@@ -1,20 +1,3 @@
-apiVersion: certmanager.k8s.io/v1alpha1
-kind: Issuer
-metadata:
-  name: gatekeeper-selfsigned-issuer
-spec:
-  selfSigned: {}
----
-apiVersion: certmanager.k8s.io/v1alpha1
-kind: Certificate
-metadata:
-  name: gatekeeper-serving-cert
-spec:
-  issuerRef:
-    kind: Issuer
-    name: gatekeeper-selfsigned-issuer
-  secretName: gatekeeper-webhook-server-cert
----
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Including cert-manager in the base creates a hard requirement on a non-native service. The
certificate and the injector annotation need to be patched anyway, so it seems better to move
it all out of the base and make the base more generically usable.