### PR TITLE
v3.1.0-beta.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,12 @@ COPY ./cluster cluster
 COPY ./namespaced namespaced
 COPY ./example example
 
-RUN wget -O kustomize \
-    https://github.com/kubernetes-sigs/kustomize/releases/download/v3.1.0/kustomize_3.1.0_linux_amd64
-RUN chmod 755 kustomize
+ENV KUSTOMIZE_VERSION="v3.5.4"
 
-RUN ./kustomize build cluster
-RUN ./kustomize build namespaced
-RUN ./kustomize build example
+RUN \
+    wget -O - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz |\
+    tar xz -C /usr/local/bin/
+
+RUN kustomize build cluster
+RUN kustomize build namespaced
+RUN kustomize build example

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Reference them in your `kustomization.yaml`, like so:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-  - github.com/utilitywarehouse/gatekeeper-manifests/cluster?ref=3.1.0-beta.2-2
-  - github.com/utilitywarehouse/gatekeeper-manifests/namespaced?ref=3.1.0-beta.2-2
+  - github.com/utilitywarehouse/gatekeeper-manifests/cluster?ref=3.1.0-beta.5-1
+  - github.com/utilitywarehouse/gatekeeper-manifests/namespaced?ref=3.1.0-beta.5-1
 ```
 
 Define the gatekeeper configuration suitable for your environment.
@@ -27,8 +27,6 @@ Refer to the `example/`.
 
 Note that you need to [provide the `ClusterRoleBinding` for gatekeeper's service
 account](example/rbac.yaml). This is required in order to keep the base namespace-agnostic.
-
-The `namespaced` base sets the `--disable-cert-rotation` flag, which means you must manage the webhook certificate, in a secret called `gatekeeper-webhook-server-cert`, separately. Additionally, the CA certificate must be injected into the `ValidatingWebhookConfiguration`. The example uses cert-manager and cert-manager's cainjector to achieve both things.
 
 ## Requires
 

--- a/cluster/gatekeeper-cluster-role.yaml
+++ b/cluster/gatekeeper-cluster-role.yaml
@@ -2,58 +2,21 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
+  labels:
+    gatekeeper.sh/system: "yes"
   name: gatekeeper-manager-role
 rules:
   - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - services
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - "*"
     resources:
       - "*"
     verbs:
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - admissionregistration.k8s.io
     resources:
-      - mutatingwebhookconfigurations
       - validatingwebhookconfigurations
     verbs:
       - create

--- a/cluster/gatekeeper-crds.yaml
+++ b/cluster/gatekeeper-crds.yaml
@@ -2,8 +2,10 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.2
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
+  labels:
+    gatekeeper.sh/system: "yes"
   name: configs.config.gatekeeper.sh
 spec:
   group: config.gatekeeper.sh
@@ -21,13 +23,13 @@ spec:
           description:
             "APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources"
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
           type: string
         kind:
           description:
             "Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
           type: string
         metadata:
           type: object
@@ -85,28 +87,6 @@ spec:
           type: object
         status:
           description: ConfigStatus defines the observed state of Config
-          properties:
-            byPod:
-              description: List of statuses as seen by individual pods
-              items:
-                properties:
-                  allFinalizers:
-                    description: List of Group/Version/Kinds with finalizers
-                    items:
-                      properties:
-                        group:
-                          type: string
-                        kind:
-                          type: string
-                        version:
-                          type: string
-                      type: object
-                    type: array
-                  id:
-                    description: a unique identifier for the pod that wrote the status
-                    type: string
-                type: object
-              type: array
           type: object
       type: object
   version: v1alpha1
@@ -141,13 +121,13 @@ spec:
           description:
             "APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources"
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
           type: string
         kind:
           description:
             "Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
           type: string
         metadata:
           type: object
@@ -161,6 +141,10 @@ spec:
                       properties:
                         kind:
                           type: string
+                        shortNames:
+                          items:
+                            type: string
+                          type: array
                       type: object
                     validation:
                       type: object

--- a/cluster/gatekeeper-webhook.yaml
+++ b/cluster/gatekeeper-webhook.yaml
@@ -1,6 +1,9 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
+  creationTimestamp: null
+  labels:
+    gatekeeper.sh/system: "yes"
   name: gatekeeper-validating-webhook-configuration
 webhooks:
   - name: validation.gatekeeper.sh
@@ -13,5 +16,25 @@ webhooks:
       matchExpressions:
         - key: control-plane
           operator: DoesNotExist
+        - key: admission.gatekeeper.sh/ignore
+          operator: DoesNotExist
+    sideEffects: None
+    timeoutSeconds: 5
+  - name: check-ignore-label.gatekeeper.sh
+    clientConfig:
+      service:
+        name: gatekeeper-webhook-service
+        path: /v1/admitlabel
+    failurePolicy: Fail
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - "*"
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - namespaces
     sideEffects: None
     timeoutSeconds: 5

--- a/example/gatekeeper-patch.yaml
+++ b/example/gatekeeper-patch.yaml
@@ -23,3 +23,26 @@ webhooks:
         resources:
           - "namespaces"
           - "ingresses"
+  - name: check-ignore-label.gatekeeper.sh
+    clientConfig:
+      service:
+        # Placeholder, patch with the gatekeeper namespace value
+        namespace: example-namespace
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gatekeeper-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          args:
+            - --audit-interval=30
+            - --port=8443
+            - --logtostderr
+            - --disable-cert-rotation
+            # Placeholder, patch with the gatekeeper namespace value and any
+            # other namespaces you want to exclude from the webhook
+            - --exempt-namespace=example-namespace

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -2,9 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
   - ../cluster
-  #  - github.com/utilitywarehouse/gatekeeper-manifests/cluster?ref=3.1.0-beta.2-2
+  #  - github.com/utilitywarehouse/gatekeeper-manifests/cluster?ref=3.1.0-beta.5-1
   - ../namespaced
-  #  - github.com/utilitywarehouse/gatekeeper-manifests/namespaced?ref=3.1.0-beta.2-2
+  #  - github.com/utilitywarehouse/gatekeeper-manifests/namespaced?ref=3.1.0-beta.5-1
+commonLabels:
+  gatekeeper.sh/system: "yes"
 patchesStrategicMerge:
   - gatekeeper-patch.yaml
 resources:

--- a/example/rbac.yaml
+++ b/example/rbac.yaml
@@ -8,6 +8,20 @@ roleRef:
   name: gatekeeper-manager-role
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: gatekeeper-admin
+    # Placeholder, patch with the gatekeeper namespace value
+    namespace: example-namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gatekeeper-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gatekeeper-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: gatekeeper-admin
     # Placeholder, patch with the gatekeeper namespace value
     namespace: example-namespace

--- a/namespaced/gatekeeper.yaml
+++ b/namespaced/gatekeeper.yaml
@@ -1,6 +1,22 @@
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: gatekeeper-admin
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: gatekeeper-webhook-server-cert
+---
+apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    gatekeeper.sh/system: "yes"
   name: gatekeeper-webhook-service
 spec:
   ports:
@@ -8,29 +24,32 @@ spec:
       targetPort: 8443
   selector:
     control-plane: controller-manager
+    gatekeeper.sh/system: "yes"
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
+    gatekeeper.sh/system: "yes"
   name: gatekeeper-controller-manager
 spec:
   replicas: 1
   selector:
     matchLabels:
       control-plane: controller-manager
+      gatekeeper.sh/system: "yes"
   template:
     metadata:
       labels:
         control-plane: controller-manager
+        gatekeeper.sh/system: "yes"
     spec:
       containers:
         - args:
-            - --auditInterval=30
+            - --audit-interval=30
             - --port=8443
             - --logtostderr
-            - --disable-cert-rotation
           command:
             - /manager
           env:
@@ -43,13 +62,27 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          image: quay.io/open-policy-agent/gatekeeper:v3.1.0-beta.2
+          image: quay.io/open-policy-agent/gatekeeper:v3.1.0-beta.5
           imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9090
           name: manager
           ports:
             - containerPort: 8443
               name: webhook-server
               protocol: TCP
+            - containerPort: 8888
+              name: metrics
+              protocol: TCP
+            - containerPort: 9090
+              name: healthz
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 9090
           resources:
             limits:
               # increased from the relatively low defaults provided by the upstream manifest; 100m cpu caused very slow request
@@ -68,6 +101,7 @@ spec:
             - mountPath: /certs
               name: cert
               readOnly: true
+      serviceAccountName: gatekeeper-admin
       terminationGracePeriodSeconds: 60
       volumes:
         - name: cert

--- a/namespaced/kustomization.yaml
+++ b/namespaced/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - gatekeeper.yaml
+  - rbac.yaml

--- a/namespaced/rbac.yaml
+++ b/namespaced/rbac.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: gatekeeper-manager-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch


### PR DESCRIPTION
* Includes changes from:
  * https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.1.0-beta.5
  * https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.1.0-beta.4
  * https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.1.0-beta.3
* Updates the tests to use the latest kustomize version
* Removes the assumption that the cert is managed by a separate process (cert-manager) from the base completely. This can be handled entirely in the patch.