### PR TITLE
Add custom limits/requests for the audit controller

### DIFF
--- a/namespaced/gatekeeper.yaml
+++ b/namespaced/gatekeeper.yaml
@@ -92,9 +92,10 @@ spec:
               path: /readyz
               port: 9090
           resources:
+            # increased from the relatively low defaults provided by the
+            # upstream manifest; a limit of 100m cpu resulted in frequent
+            # throttling which caused very slow request latencies to the api server
             limits:
-              # increased from the relatively low defaults provided by the upstream manifest; 100m cpu caused very slow request
-              # latencies to the api server
               cpu: 7000m
               memory: 1000Mi
             requests:
@@ -181,11 +182,12 @@ spec:
               path: /readyz
               port: 9090
           resources:
+            # increased from the relatively low defaults provided by the upstream manifest
             limits:
-              cpu: 1000m
-              memory: 512Mi
+              cpu: 2000m
+              memory: 1000Mi
             requests:
-              cpu: 100m
+              cpu: 200m
               memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Some of the most resource intensive functions of gatekeeper have been split off into the audit controller, so it's deserving of some of the custom defaults we established when the webhook and the audit were ran in the same pod.

I'm only limiting the audit to 2000m, rather than 7000m because it doesn't have the same potential to slow down requests on the api server that the webhook does when its throttled.