### PR TITLE
Set audit-from-cache to true

### DIFF
--- a/namespaced/gatekeeper.yaml
+++ b/namespaced/gatekeeper.yaml
@@ -151,6 +151,7 @@ spec:
         - args:
             - --operation=audit
             - --logtostderr
+            - --audit-from-cache=true
           command:
             - /manager
           env:


### PR DESCRIPTION
By default the gatekeeper audit will use the k8s discovery client to discover objects based on the selectors present on the constraint. This is a lot more CPU and memory intensive than the previous default which used the objects cached for use in OPA policies, which are synced according to a predefined list of resource types.

As we're only using a small, known subset of resource types for our constraints, I think it's preferable to use the OPA cache.

Here you can see the distinct difference in memory and CPU before and after setting this flag:
<img width="1329" alt="Screenshot 2020-06-10 at 15 29 47" src="https://user-images.githubusercontent.com/9870923/84280489-42c15300-ab2f-11ea-90e5-f7a2e85ee638.png">
