### PR TITLE
Revert to auditing with the discovery client and increase limits

### DIFF
--- a/namespaced/gatekeeper.yaml
+++ b/namespaced/gatekeeper.yaml
@@ -97,7 +97,7 @@ spec:
             # throttling which caused very slow request latencies to the api server
             limits:
               cpu: 7000m
-              memory: 1000Mi
+              memory: 4000Mi
             requests:
               cpu: 200m
               memory: 256Mi
@@ -185,8 +185,8 @@ spec:
           resources:
             # increased from the relatively low defaults provided by the upstream manifest
             limits:
-              cpu: 2000m
-              memory: 1000Mi
+              cpu: 7000m
+              memory: 4000Mi
             requests:
               cpu: 200m
               memory: 256Mi

--- a/namespaced/gatekeeper.yaml
+++ b/namespaced/gatekeeper.yaml
@@ -151,7 +151,6 @@ spec:
         - args:
             - --operation=audit
             - --logtostderr
-            - --audit-from-cache=true
           command:
             - /manager
           env:


### PR DESCRIPTION
There's a tradeoff between auditing with the discovery client vs auditing from
the OPA cache.
- Auditing from the cache uses less CPU and makes less calls to the API server but uses more memory as you sync more and more objects. Both the audit and controller-manager containers sync the cache, so memory increases for both as the cache grows. Adding pods to the prod-aws sync increased memory usage by ~2GB.
- Using the discovery client without an OPA cache adds ~1 CPU and ~50kB/s network traffic but slices memory usage down from ~5GB between the two containers to ~200MB. There is no noticable or dramatic uptick in request rate or latency on the API server that I can see.

If we were syncing objects to the OPA cache for use in policies then it might make sense to audit from the cache. But seen as we don't actually need the cache at all, using the discovery client gives gatekeeper the lowest overall resource profile.

If we ever need to sync objects to the OPA cache for use in policies, then we can revisit this.

I've also increased resource limits for both containers to give a bit more headroom to absorb future jumps in resource usage.