### PR TITLE
v3.4.0 and improve update/release procedure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.rego
+gatekeeper-*.tgz

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,37 @@
 SHELL := /bin/bash
+HELM_VERSION=3.4.0
 
+.PHONY: test
 test:
 	@docker build -t gatekeeper-manifests .
 
+.PHONY: install-git-hooks
 install-git-hooks:
 	@-rm -r .git/hooks
 	@ln -sv ../lib/git-hooks .git/hooks
 
-# Hack to take arguments from command line
-# Usage: `make release 3.1.0-beta.7`
-# https://stackoverflow.com/questions/6273608/how-to-pass-argument-to-makefile-from-command-line
-release:
-	@sed -i 's#\(gatekeeper-manifests/.*?ref=\).*#\1$(filter-out $@,$(MAKECMDGOALS))#g' README.md example/kustomization.yaml
+.PHONY: helm
+helm: helm-fetch helm-cluster helm-namespaced
 
-%:		# matches any task name
-	@:	# empty recipe = do nothing
+.PHONY: helm-fetch
+helm-fetch:
+	helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts
+	helm repo update
+	helm fetch --version=$(HELM_VERSION) 'gatekeeper/gatekeeper'
+
+.PHONY: helm-cluster
+helm-cluster: helm-fetch
+	# - Select resources without a namespace field
+	# - Exclude ClusterRoleBindings (should be set in the overlay)
+	helm template --release-name --include-crds --set postInstall.labelNamespace.enabled=false gatekeeper gatekeeper-$(HELM_VERSION).tgz | \
+		yq eval 'select(.metadata | has("namespace") | not) | select(.kind != "ClusterRoleBinding")' - \
+		> cluster/gatekeeper.yaml
+
+.PHONY: helm-namespaced
+helm-namespaced: helm-fetch
+	# - Select resources with a namespace field
+	# - Exclude RoleBindings (should be set in the overlay)
+	# - Remove the namespace field
+	helm template --release-name gatekeeper --set postInstall.labelNamespace.enabled=false gatekeeper-$(HELM_VERSION).tgz | \
+		yq eval 'select(.metadata | has("namespace")) | select(.kind != "RoleBinding") | del(.metadata.namespace)' - \
+		> namespaced/gatekeeper.yaml

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Reference them in your `kustomization.yaml`, like so:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-  - github.com/utilitywarehouse/gatekeeper-manifests/cluster?ref=3.3.0-1
-  - github.com/utilitywarehouse/gatekeeper-manifests/namespaced?ref=3.3.0-1
+  - github.com/utilitywarehouse/gatekeeper-manifests/cluster
+  - github.com/utilitywarehouse/gatekeeper-manifests/namespaced
 ```
 
 Define the gatekeeper configuration suitable for your environment.
@@ -30,21 +30,22 @@ account](example/rbac.yaml). This is required in order to keep the base namespac
 
 ## Update
 
+To update the upstream version, edit `HELM_VERSION` in the
+[`Makefile`](Makefile) and run:
+
 ```
-helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts
-helm repo update
-helm fetch gatekeeper/gatekeeper
-helm template --name gatekeeper gatekeeper-3.1.1.tgz
+make helm
 ```
 
-Then:
+Note: requires `helm` v3 and `yq` v3.
 
-- Split cluster and namespace scoped resources into `cluster/gatekeeper.yaml` and
-  `namespaced/gatekeeper.yaml`, respectively.
-- Remove `Namespace`, `ClusterRoleBinding` and `RoleBinding` resources
-- Remove the `metadata.namespace` field from all the namespaced resources
-- Update any patches in `{cluster,namespaced}/gatekeeper-patch.yaml` to account
-  for upstream changes
+This will update the files:
+- [`cluster/gatekeeper.yaml`](cluster/gatekeeper.yaml)
+- [`namespaced/gatekeeper.yaml`](namespaced/gatekeeper.yaml)
+
+Patch changes on top of the upstream in the patches:
+- [`cluster/gatekeeper-patch.yaml`](cluster/gatekeeper-patch.yaml)
+- [`namespaced/gatekeeper-patch.yaml`](namespaced/gatekeeper-patch.yaml)
 
 ## Requires
 

--- a/cluster/gatekeeper.yaml
+++ b/cluster/gatekeeper.yaml
@@ -1,49 +1,337 @@
-# Source: gatekeeper/templates/gatekeeper-admin-podsecuritypolicy.yaml
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: "*"
-  labels:
-    app: "gatekeeper"
-    chart: "gatekeeper"
-    gatekeeper.sh/system: "yes"
-    heritage: "Tiller"
-    release: "gatekeeper"
-  name: gatekeeper-admin
-spec:
-  allowPrivilegeEscalation: false
-  fsGroup:
-    ranges:
-      - max: 65535
-        min: 1
-    rule: MustRunAs
-  requiredDropCapabilities:
-    - ALL
-  runAsUser:
-    rule: MustRunAsNonRoot
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    ranges:
-      - max: 65535
-        min: 1
-    rule: MustRunAs
-  volumes:
-    - configMap
-    - projected
-    - secret
-    - downwardAPI
----
-# Source: gatekeeper/templates/crds.yaml
+# Source: crds/assign-customresourcedefinition.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
-    helm.sh/hook: crd-install
-    helm.sh/hook-delete-policy: before-hook-creation
-  creationTimestamp: null
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: assign.mutations.gatekeeper.sh
+spec:
+  group: mutations.gatekeeper.sh
+  names:
+    kind: Assign
+    listKind: AssignList
+    plural: assign
+    singular: assign
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      description: Assign is the Schema for the assign API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: AssignSpec defines the desired state of Assign
+          properties:
+            applyTo:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "make" to regenerate code after modifying this file'
+              items:
+                description: ApplyTo determines what GVKs items the mutation should apply to. Globs are not allowed.
+                properties:
+                  groups:
+                    items:
+                      type: string
+                    type: array
+                  kinds:
+                    items:
+                      type: string
+                    type: array
+                  versions:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              type: array
+            location:
+              type: string
+            match:
+              properties:
+                excludedNamespaces:
+                  items:
+                    type: string
+                  type: array
+                kinds:
+                  items:
+                    description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                    properties:
+                      apiGroups:
+                        description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                        items:
+                          type: string
+                        type: array
+                      kinds:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                labelSelector:
+                  description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                namespaceSelector:
+                  description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                namespaces:
+                  items:
+                    type: string
+                  type: array
+                scope:
+                  description: ResourceScope is an enum defining the different scopes available to a custom resource
+                  type: string
+              required:
+                - scope
+              type: object
+            parameters:
+              properties:
+                assign:
+                  description: Assign.value holds the value to be assigned
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                ifIn:
+                  description: IfIn Only mutate if the current value is in the supplied list
+                  items:
+                    type: string
+                  type: array
+                ifNotIn:
+                  description: IfNotIn Only mutate if the current value is NOT in the supplied list
+                  items:
+                    type: string
+                  type: array
+                pathTests:
+                  items:
+                    description: "PathTests allows the user to customize how the mutation works if parent paths are missing. It traverses the list in order. All sub paths are tested against the provided condition, if the test fails, the mutation is not applied. All `subPath` entries must be a prefix of `location`. Any glob characters will take on the same value as was used to expand the matching glob in `location`. \n Available Tests: * MustExist    - the path must exist or do not mutate * MustNotExist - the path must not exist or do not mutate"
+                    properties:
+                      condition:
+                        enum:
+                          - MustExist
+                          - MustNotExist
+                        type: string
+                      subPath:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+        status:
+          description: AssignStatus defines the observed state of Assign
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+---
+# Source: crds/assignmetadata-customresourcedefinition.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: assignmetadata.mutations.gatekeeper.sh
+spec:
+  group: mutations.gatekeeper.sh
+  names:
+    kind: AssignMetadata
+    listKind: AssignMetadataList
+    plural: assignmetadata
+    singular: assignmetadata
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      description: AssignMetadata is the Schema for the assignmetadata API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: AssignMetadataSpec defines the desired state of AssignMetadata
+          properties:
+            location:
+              type: string
+            match:
+              properties:
+                excludedNamespaces:
+                  items:
+                    type: string
+                  type: array
+                kinds:
+                  items:
+                    description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                    properties:
+                      apiGroups:
+                        description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                        items:
+                          type: string
+                        type: array
+                      kinds:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                labelSelector:
+                  description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                namespaceSelector:
+                  description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                namespaces:
+                  items:
+                    type: string
+                  type: array
+                scope:
+                  description: ResourceScope is an enum defining the different scopes available to a custom resource
+                  type: string
+              required:
+                - scope
+              type: object
+            parameters:
+              properties:
+                assign:
+                  description: Assign.value holds the value to be assigned
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+          type: object
+        status:
+          description: AssignMetadataStatus defines the observed state of AssignMetadata
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+---
+# Source: crds/config-customresourcedefinition.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
   labels:
     gatekeeper.sh/system: "yes"
   name: configs.config.gatekeeper.sh
@@ -62,10 +350,10 @@ spec:
       description: Config is the Schema for the configs API
       properties:
         apiVersion:
-          description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -145,14 +433,12 @@ spec:
       served: true
       storage: true
 ---
+# Source: crds/constraintpodstatus-customresourcedefinition.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
-    helm.sh/hook: crd-install
-    helm.sh/hook-delete-policy: before-hook-creation
-  creationTimestamp: null
   labels:
     gatekeeper.sh/system: "yes"
   name: constraintpodstatuses.status.gatekeeper.sh
@@ -169,10 +455,10 @@ spec:
       description: ConstraintPodStatus is the Schema for the constraintpodstatuses API
       properties:
         apiVersion:
-          description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -216,13 +502,10 @@ spec:
       served: true
       storage: true
 ---
+# Source: crds/constrainttemplate-customresourcedefinition.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    helm.sh/hook: crd-install
-    helm.sh/hook-delete-policy: before-hook-creation
-  creationTimestamp: null
   labels:
     gatekeeper.sh/system: "yes"
   name: constrainttemplates.templates.gatekeeper.sh
@@ -238,10 +521,10 @@ spec:
     openAPIV3Schema:
       properties:
         apiVersion:
-          description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -317,14 +600,12 @@ spec:
       served: true
       storage: false
 ---
+# Source: crds/constrainttemplatepodstatus-customresourcedefinition.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
-    helm.sh/hook: crd-install
-    helm.sh/hook-delete-policy: before-hook-creation
-  creationTimestamp: null
   labels:
     gatekeeper.sh/system: "yes"
   name: constrainttemplatepodstatuses.status.gatekeeper.sh
@@ -341,10 +622,10 @@ spec:
       description: ConstraintTemplatePodStatus is the Schema for the constrainttemplatepodstatuses API
       properties:
         apiVersion:
-          description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -387,23 +668,60 @@ spec:
       served: true
       storage: true
 ---
+# Source: gatekeeper/templates/gatekeeper-admin-podsecuritypolicy.yaml
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+  labels:
+    app: 'gatekeeper'
+    chart: 'gatekeeper'
+    gatekeeper.sh/system: "yes"
+    heritage: 'Helm'
+    release: 'gatekeeper'
+  name: gatekeeper-admin
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+      - max: 65535
+        min: 1
+    rule: MustRunAs
+  requiredDropCapabilities:
+    - ALL
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+      - max: 65535
+        min: 1
+    rule: MustRunAs
+  volumes:
+    - configMap
+    - projected
+    - secret
+    - downwardAPI
+---
 # Source: gatekeeper/templates/gatekeeper-manager-role-clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
   labels:
-    app: "gatekeeper"
-    chart: "gatekeeper"
+    app: 'gatekeeper'
+    chart: 'gatekeeper'
     gatekeeper.sh/system: "yes"
-    heritage: "Tiller"
-    release: "gatekeeper"
+    heritage: 'Helm'
+    release: 'gatekeeper'
   name: gatekeeper-manager-role
 rules:
   - apiGroups:
-      - "*"
+      - '*'
     resources:
-      - "*"
+      - '*'
     verbs:
       - get
       - list
@@ -443,7 +761,7 @@ rules:
   - apiGroups:
       - constraints.gatekeeper.sh
     resources:
-      - "*"
+      - '*'
     verbs:
       - create
       - delete
@@ -455,7 +773,7 @@ rules:
   - apiGroups:
       - mutations.gatekeeper.sh
     resources:
-      - "*"
+      - '*'
     verbs:
       - create
       - delete
@@ -475,7 +793,7 @@ rules:
   - apiGroups:
       - status.gatekeeper.sh
     resources:
-      - "*"
+      - '*'
     verbs:
       - create
       - delete
@@ -527,25 +845,38 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resourceNames:
+      - gatekeeper-mutating-webhook-configuration
+    resources:
+      - mutatingwebhookconfigurations
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 # Source: gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   labels:
-    app: "gatekeeper"
-    chart: "gatekeeper"
+    app: 'gatekeeper'
+    chart: 'gatekeeper'
     gatekeeper.sh/system: "yes"
-    heritage: "Tiller"
-    release: "gatekeeper"
+    heritage: 'Helm'
+    release: 'gatekeeper'
   name: gatekeeper-validating-webhook-configuration
 webhooks:
   - clientConfig:
       caBundle: Cg==
       service:
         name: gatekeeper-webhook-service
-        namespace: gatekeeper-system
+        namespace: 'default'
         path: /v1/admit
     failurePolicy: Ignore
     name: validation.gatekeeper.sh
@@ -555,21 +886,21 @@ webhooks:
           operator: DoesNotExist
     rules:
       - apiGroups:
-          - "*"
+          - '*'
         apiVersions:
-          - "*"
+          - '*'
         operations:
           - CREATE
           - UPDATE
         resources:
-          - "*"
+          - '*'
     sideEffects: None
     timeoutSeconds: 3
   - clientConfig:
       caBundle: Cg==
       service:
         name: gatekeeper-webhook-service
-        namespace: gatekeeper-system
+        namespace: 'default'
         path: /v1/admitlabel
     failurePolicy: Fail
     name: check-ignore-label.gatekeeper.sh
@@ -577,7 +908,7 @@ webhooks:
       - apiGroups:
           - ""
         apiVersions:
-          - "*"
+          - '*'
         operations:
           - CREATE
           - UPDATE

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -2,9 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
   - ../cluster
-  #  - github.com/utilitywarehouse/gatekeeper-manifests/cluster?ref=3.3.0-1
+  #  - github.com/utilitywarehouse/gatekeeper-manifests/cluster
   - ../namespaced
-  #  - github.com/utilitywarehouse/gatekeeper-manifests/namespaced?ref=3.3.0-1
+  #  - github.com/utilitywarehouse/gatekeeper-manifests/namespaced
 commonLabels:
   gatekeeper.sh/system: "yes"
 patchesStrategicMerge:

--- a/namespaced/gatekeeper-patch.yaml
+++ b/namespaced/gatekeeper-patch.yaml
@@ -26,10 +26,12 @@ spec:
           args:
             - --port=8443
             - --logtostderr
+            - --log-denies=false
             - --emit-admission-events=false
             - --log-level=INFO
             - --exempt-namespace=$(POD_NAMESPACE)
             - --operation=webhook
+            - --enable-mutation=false
             - --disable-cert-rotation
           resources:
             limits:

--- a/namespaced/gatekeeper.yaml
+++ b/namespaced/gatekeeper.yaml
@@ -1,27 +1,50 @@
-# Source: gatekeeper/templates/gatekeeper-webhook-server-cert-secret.yaml
-apiVersion: v1
-kind: Secret
+# Source: gatekeeper/templates/gatekeeper-controller-manager-poddisruptionbudget.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
 metadata:
-  annotations: {}
   labels:
-    app: "gatekeeper"
-    chart: "gatekeeper"
+    app: 'gatekeeper'
+    chart: 'gatekeeper'
     gatekeeper.sh/system: "yes"
-    heritage: "Tiller"
-    release: "gatekeeper"
-  name: gatekeeper-webhook-server-cert
+    heritage: 'Helm'
+    release: 'gatekeeper'
+  name: gatekeeper-controller-manager
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: 'gatekeeper'
+      chart: 'gatekeeper'
+      control-plane: controller-manager
+      gatekeeper.sh/operation: webhook
+      gatekeeper.sh/system: "yes"
+      heritage: 'Helm'
+      release: 'gatekeeper'
 ---
 # Source: gatekeeper/templates/gatekeeper-admin-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: "gatekeeper"
-    chart: "gatekeeper"
+    app: 'gatekeeper'
+    chart: 'gatekeeper'
     gatekeeper.sh/system: "yes"
-    heritage: "Tiller"
-    release: "gatekeeper"
+    heritage: 'Helm'
+    release: 'gatekeeper'
   name: gatekeeper-admin
+---
+# Source: gatekeeper/templates/gatekeeper-webhook-server-cert-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    app: 'gatekeeper'
+    chart: 'gatekeeper'
+    gatekeeper.sh/system: "yes"
+    heritage: 'Helm'
+    release: 'gatekeeper'
+  name: gatekeeper-webhook-server-cert
 ---
 # Source: gatekeeper/templates/gatekeeper-manager-role-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -29,11 +52,11 @@ kind: Role
 metadata:
   creationTimestamp: null
   labels:
-    app: "gatekeeper"
-    chart: "gatekeeper"
+    app: 'gatekeeper'
+    chart: 'gatekeeper'
     gatekeeper.sh/system: "yes"
-    heritage: "Tiller"
-    release: "gatekeeper"
+    heritage: 'Helm'
+    release: 'gatekeeper'
   name: gatekeeper-manager-role
 rules:
   - apiGroups:
@@ -61,62 +84,63 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: "gatekeeper"
-    chart: "gatekeeper"
+    app: 'gatekeeper'
+    chart: 'gatekeeper'
     gatekeeper.sh/system: "yes"
-    heritage: "Tiller"
-    release: "gatekeeper"
+    heritage: 'Helm'
+    release: 'gatekeeper'
   name: gatekeeper-webhook-service
 spec:
   ports:
     - port: 443
       targetPort: 8443
   selector:
-    app: "gatekeeper"
-    chart: "gatekeeper"
+    app: 'gatekeeper'
+    chart: 'gatekeeper'
     control-plane: controller-manager
     gatekeeper.sh/operation: webhook
     gatekeeper.sh/system: "yes"
-    heritage: "Tiller"
-    release: "gatekeeper"
+    heritage: 'Helm'
+    release: 'gatekeeper'
 ---
 # Source: gatekeeper/templates/gatekeeper-audit-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: "gatekeeper"
-    chart: "gatekeeper"
+    app: 'gatekeeper'
+    chart: 'gatekeeper'
     control-plane: audit-controller
     gatekeeper.sh/operation: audit
     gatekeeper.sh/system: "yes"
-    heritage: "Tiller"
-    release: "gatekeeper"
+    heritage: 'Helm'
+    release: 'gatekeeper'
   name: gatekeeper-audit
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "gatekeeper"
-      chart: "gatekeeper"
+      app: 'gatekeeper'
+      chart: 'gatekeeper'
       control-plane: audit-controller
       gatekeeper.sh/operation: audit
       gatekeeper.sh/system: "yes"
-      heritage: "Tiller"
-      release: "gatekeeper"
+      heritage: 'Helm'
+      release: 'gatekeeper'
   template:
     metadata:
       annotations:
         container.seccomp.security.alpha.kubernetes.io/manager: runtime/default
       labels:
-        app: "gatekeeper"
-        chart: "gatekeeper"
+        app: 'gatekeeper'
+        chart: 'gatekeeper'
         control-plane: audit-controller
         gatekeeper.sh/operation: audit
         gatekeeper.sh/system: "yes"
-        heritage: "Tiller"
-        release: "gatekeeper"
+        heritage: 'Helm'
+        release: 'gatekeeper'
     spec:
+      affinity: {}
       automountServiceAccountToken: true
       containers:
         - args:
@@ -141,8 +165,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          image: "openpolicyagent/gatekeeper:v3.3.0"
-          imagePullPolicy: "IfNotPresent"
+          image: 'openpolicyagent/gatekeeper:v3.4.0'
+          imagePullPolicy: 'IfNotPresent'
           livenessProbe:
             httpGet:
               path: /healthz
@@ -166,7 +190,6 @@ spec:
             requests:
               cpu: 100m
               memory: 256Mi
-
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -176,55 +199,50 @@ spec:
             runAsGroup: 999
             runAsNonRoot: true
             runAsUser: 1000
+      hostNetwork: false
+      imagePullSecrets: []
       nodeSelector:
         kubernetes.io/os: linux
-
-      affinity: {}
-
-      tolerations: []
-
-      imagePullSecrets: []
-
-      priorityClassName: system-cluster-critical
       serviceAccountName: gatekeeper-admin
       terminationGracePeriodSeconds: 60
+      tolerations: []
 ---
 # Source: gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: "gatekeeper"
-    chart: "gatekeeper"
+    app: 'gatekeeper'
+    chart: 'gatekeeper'
     control-plane: controller-manager
     gatekeeper.sh/operation: webhook
     gatekeeper.sh/system: "yes"
-    heritage: "Tiller"
-    release: "gatekeeper"
+    heritage: 'Helm'
+    release: 'gatekeeper'
   name: gatekeeper-controller-manager
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: "gatekeeper"
-      chart: "gatekeeper"
+      app: 'gatekeeper'
+      chart: 'gatekeeper'
       control-plane: controller-manager
       gatekeeper.sh/operation: webhook
       gatekeeper.sh/system: "yes"
-      heritage: "Tiller"
-      release: "gatekeeper"
+      heritage: 'Helm'
+      release: 'gatekeeper'
   template:
     metadata:
       annotations:
         container.seccomp.security.alpha.kubernetes.io/manager: runtime/default
       labels:
-        app: "gatekeeper"
-        chart: "gatekeeper"
+        app: 'gatekeeper'
+        chart: 'gatekeeper'
         control-plane: controller-manager
         gatekeeper.sh/operation: webhook
         gatekeeper.sh/system: "yes"
-        heritage: "Tiller"
-        release: "gatekeeper"
+        heritage: 'Helm'
+        release: 'gatekeeper'
     spec:
       affinity:
         podAntiAffinity:
@@ -243,10 +261,12 @@ spec:
         - args:
             - --port=8443
             - --logtostderr
+            - --log-denies=false
             - --emit-admission-events=false
             - --log-level=INFO
-            - --exempt-namespace=gatekeeper-system
+            - --exempt-namespace=default
             - --operation=webhook
+            - --enable-mutation=false
           command:
             - /manager
           env:
@@ -259,8 +279,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          image: "openpolicyagent/gatekeeper:v3.3.0"
-          imagePullPolicy: "IfNotPresent"
+          image: 'openpolicyagent/gatekeeper:v3.4.0'
+          imagePullPolicy: 'IfNotPresent'
           livenessProbe:
             httpGet:
               path: /healthz
@@ -287,7 +307,6 @@ spec:
             requests:
               cpu: 100m
               memory: 256Mi
-
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -301,16 +320,13 @@ spec:
             - mountPath: /certs
               name: cert
               readOnly: true
+      hostNetwork: false
+      imagePullSecrets: []
       nodeSelector:
         kubernetes.io/os: linux
-
-      tolerations: []
-
-      imagePullSecrets: []
-
-      priorityClassName: system-cluster-critical
       serviceAccountName: gatekeeper-admin
       terminationGracePeriodSeconds: 60
+      tolerations: []
       volumes:
         - name: cert
           secret:


### PR DESCRIPTION
- Rather than providing a list of steps to split the helm upstream into cluster/namespaced resources, use yq to do it automatically for us
- Remove the `release` target, all it was doing was updating examples