### PR TITLE
Adjust audit CPU/memory limits

### DIFF
--- a/namespaced/gatekeeper-patch.yaml
+++ b/namespaced/gatekeeper-patch.yaml
@@ -23,8 +23,8 @@ spec:
             - --audit-chunk-size=500
           resources:
             limits:
-              cpu: 7000m
-              memory: 4000Mi
+              cpu: 2500m
+              memory: 1000Mi
             requests:
               cpu: 200m
 ---


### PR DESCRIPTION
The controller serves the webhook which has the potential to dramatically impact apiserver performance if it was OOM killed or CPU throttled, hence the high limits.

The audit manager on the other hand could be throttled/OOM killed without affecting cluster functionality and therefore doesn't necessarily justify the sky high limits.