### PR TITLE
Reduce cpu limit to 6000m

### DIFF
--- a/namespaced/gatekeeper-patch.yaml
+++ b/namespaced/gatekeeper-patch.yaml
@@ -49,7 +49,7 @@ spec:
             - --disable-cert-rotation
           resources:
             limits:
-              cpu: 7000m
+              cpu: 6000m
               memory: 4000Mi
             requests:
               cpu: 200m


### PR DESCRIPTION
This is the new max in our clusters:
```
Error creating: pods "gatekeeper-controller-manager-56f848bc94-fnkvg" is forbidden: maximum cpu usage per Container is 6, but limit is 7
```